### PR TITLE
chore: guard DOM usage in main

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,58 +1,57 @@
 // Import our custom CSS
 import './styles.scss'
-// Import all of Bootstrap's JS
-import * as bootstrap from 'bootstrap'
-import ls from 'localstorage-slim';
 
-window.addEventListener('DOMContentLoaded', (event) => {
+if (typeof window !== 'undefined') {
+    window.addEventListener('DOMContentLoaded', async (event) => {
+        const bootstrap = await import('bootstrap');
 
-    var canvas = document.getElementById("offcanvasNav");
-    var bscanvas = new bootstrap.Offcanvas(canvas);
-    document.querySelectorAll('.accordion-body a').forEach((el) => {
-        el.addEventListener('click', () => {
-            bscanvas.hide();
+        var canvas = document.getElementById("offcanvasNav");
+        var bscanvas = new bootstrap.Offcanvas(canvas);
+        document.querySelectorAll('.accordion-body a').forEach((el) => {
+            el.addEventListener('click', () => {
+                bscanvas.hide();
+            });
         });
-    });
 
 
-    document.getElementById("form").addEventListener('submit', (e) => {
-        e.preventDefault();
+        document.getElementById("form").addEventListener('submit', (e) => {
+            e.preventDefault();
 
-        const data = new FormData(e.target);
-        var j_data = {}
-        for (var pair of data.entries()) {
-            j_data[pair[0]] = pair[1]
-        }
-        e.target.innerHTML = "<div class='spinner-border' role='status'>  <span class='visually-hidden'>Loading...</span> </div>";
-        fetch("https://prod-127.westus.logic.azure.com:443/workflows/e8dbf58121424e3296c49cfd09c73723/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=LRBM3KKA0hhd3p6K-42GPUfXxnkee-XRhM1Zj5UOUzU", {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(j_data)
-        }).then((res) => {
-            document.getElementById("form").innerHTML = "<h2>Message Sent!</h2>";
+            const data = new FormData(e.target);
+            var j_data = {}
+            for (var pair of data.entries()) {
+                j_data[pair[0]] = pair[1]
+            }
+            e.target.innerHTML = "<div class='spinner-border' role='status'>  <span class='visually-hidden'>Loading...</span> </div>";
+            fetch("https://prod-127.westus.logic.azure.com:443/workflows/e8dbf58121424e3296c49cfd09c73723/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=LRBM3KKA0hhd3p6K-42GPUfXxnkee-XRhM1Zj5UOUzU", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(j_data)
+            }).then((res) => {
+                document.getElementById("form").innerHTML = "<h2>Message Sent!</h2>";
 
+            });
         });
-    });
 
 
-    var data = ['Small Business', 'Law Firm', 'Non-profit', 'Construction', 'Aerospace', 'Healthcare', 'Finance', 'Engineering'];
-    var counter = 1;
-    var curr_timer = null;
-    setInterval(() => {
-        const tw = document.getElementById("type-writer");
-        tw.innerHTML = data[counter];
-        tw.classList.add("fade-in");
-        setTimeout(() => {
-            tw.classList.remove("fade-in");
-        }, 1000);
-        if (counter == data.length - 1) {
-            counter = 0;
-        }
-        else
-            counter++;
-    }, 2000);
+        var data = ['Small Business', 'Law Firm', 'Non-profit', 'Construction', 'Aerospace', 'Healthcare', 'Finance', 'Engineering'];
+        var counter = 1;
+        var curr_timer = null;
+        setInterval(() => {
+            const tw = document.getElementById("type-writer");
+            tw.innerHTML = data[counter];
+            tw.classList.add("fade-in");
+            setTimeout(() => {
+                tw.classList.remove("fade-in");
+            }, 1000);
+            if (counter == data.length - 1) {
+                counter = 0;
+            }
+            else
+                counter++;
+        }, 2000);
     // function typeWriter() {
     //     var i = 0;
     //     var txt = data[counter];
@@ -87,14 +86,15 @@ window.addEventListener('DOMContentLoaded', (event) => {
 
     // }
     // typeWriter();
-    // document.addEventListener('visibilitychange', function() {
-    //     if (document.visibilityState === 'hidden') {
-    //         clearTimeout(curr_timer);
-    //     } else {
-    //         typeWriter();
-    //     }
-    // });
-});
+        // document.addEventListener('visibilitychange', function() {
+        //     if (document.visibilityState === 'hidden') {
+        //         clearTimeout(curr_timer);
+        //     } else {
+        //         typeWriter();
+        //     }
+        // });
+    });
+}
 
 
 


### PR DESCRIPTION
## Summary
- guard DOM and bootstrap usage so main.js can be imported server-side without window

## Testing
- `npm run build`
- `curl -s -I http://localhost:4175 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_689e64c99ea0833383b13d22291fd3b6